### PR TITLE
Fix dev reload after mutation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    watch: {
+      ignored: ["**/db.json"],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- ignore `db.json` changes in Vite server to avoid dev page reloads after mutations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c166b79288320bf6b1c80429f0305